### PR TITLE
Add multilanguage support and persist user configuration in packaged app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 dist/
 .env
+.vscode/

--- a/config.json
+++ b/config.json
@@ -1,3 +1,5 @@
 {
-    "clientId": "242342342342"
+  "clientId": "242342342342",
+  "adBlockEnabled": false,
+  "minimizeToTrayEnabled": true
 }

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,32 @@
+const path = require("path");
+const fs = require("fs");
+
+let translations = {};
+
+// Carga las traducciones
+function loadTranslations(locale) {
+  try {
+    const filePath = path.join(__dirname, "locales", `${locale}.json`);
+    if (fs.existsSync(filePath)) {
+      translations = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } else {
+      // Si el archivo del idioma no existe, usa el inglés como fallback
+      console.warn(`Translation file for ${locale} not found. Falling back to 'en'.`);
+      translations = JSON.parse(fs.readFileSync(path.join(__dirname, "locales", "en.json"), "utf8"));
+    }
+  } catch (error) {
+    console.error("Error loading translation file:", error);
+    // En caso de error, inicializa un objeto vacío para evitar fallos
+    translations = {};
+  }
+}
+
+// Función de traducción
+function getTranslator(locale) {
+  loadTranslations(locale);
+  return (key) => translations[key] || key;
+}
+
+module.exports = {
+  getTranslator,
+};

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,12 @@
+{
+    "app_menu": "App",
+    "toggle_fullscreen": "Toggle Fullscreen",
+    "reload": "Reload",
+    "ad_blocker": "Ad Blocker",
+    "minimize_to_tray": "Minimize to Tray on Close",
+    "about": "About",
+    "quit": "Quit",
+    "tray_show": "Show",
+    "tray_exit": "Exit",
+    "tray_tooltip": "YouTube Music"
+  }

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,12 @@
+{
+    "app_menu": "Aplicación",
+    "toggle_fullscreen": "Pantalla Completa",
+    "reload": "Recargar",
+    "ad_blocker": "Bloquear Anuncios",
+    "minimize_to_tray": "Minimizar en Bandeja al Cerrar",
+    "about": "Acerca de",
+    "quit": "Salir",
+    "tray_show": "Mostrar",
+    "tray_exit": "Salir",
+    "tray_tooltip": "YouTube Music"
+  }

--- a/main.js
+++ b/main.js
@@ -4,6 +4,10 @@ const { app, BrowserWindow, Menu, Tray } = require("electron");
 const rpc = require("discord-rpc");
 const si = require("systeminformation");
 
+// multilanguage
+const i18n = require("./i18n.js");
+let t;
+
 //ad Blocker
 const { ElectronBlocker, fullLists, Request } = require('@ghostery/adblocker-electron');
 const fetch = require('cross-fetch');
@@ -211,6 +215,9 @@ if (!gotLock) {
   });
 
   app.on("ready", () => {
+    const appLocale = app.getLocale();
+    t = i18n.getTranslator(appLocale);
+
     mainWindow = new BrowserWindow({
       width: 1200,
       height: 800,
@@ -272,13 +279,13 @@ if (!gotLock) {
 
             const contextMenu = Menu.buildFromTemplate([
               {
-                label: "Show",
+                label: t("tray_show"),
                 click: () => {
                   mainWindow.show();
                 },
               },
               {
-                label: "Exit",
+                label: t("tray_exit"),
                 click: () => {
                   appIsQuitting = true;
                   app.quit();
@@ -305,13 +312,13 @@ if (!gotLock) {
     // Custom menu
     const menu = Menu.buildFromTemplate([
       {
-        label: "App",
+        label: t("app_menu"),
         submenu: [
-          { role: "togglefullscreen" },
-          { role: "reload" },
+          { role: "togglefullscreen", label: t("toggle_fullscreen") },
+          { role: "reload", label: t("reload") },
           { type: "separator" },
           {
-            label: "Ad Blocker",
+            label: t("ad_blocker"),
             type: "checkbox",
             checked: blocked,
             click: (menuItem) => {
@@ -320,7 +327,7 @@ if (!gotLock) {
             },
           },
           {
-            label: "Minimize to Tray on Close",
+            label: t("minimize_to_tray"),
             type: "checkbox",
             checked: minimizeToTray,
             checked: true,
@@ -328,14 +335,14 @@ if (!gotLock) {
           },
           { type: "separator" },
           {
-            label: "About",
+            label: t("about"),
             click: () => {
               const { shell } = require("electron");
               shell.openExternal("https://github.com/nubsuki/YouTube-Music-Player");
             },
           },
           {
-            label: "Quit",
+            label: t("quit"),
             accelerator: process.platform === "darwin" ? "Command+Q" : "Alt+F4",
             click: () => {
               appIsQuitting = true;

--- a/main.js
+++ b/main.js
@@ -11,24 +11,57 @@ let t;
 //ad Blocker
 const { ElectronBlocker, fullLists, Request } = require('@ghostery/adblocker-electron');
 const fetch = require('cross-fetch');
-let blocked = false;
 let blocker = null;
 
 let mainWindow;
 let tray = null;
-let minimizeToTray = true;
 let appIsQuitting = false; // Initialize app quitting state
+
+// Paths to configuration files
+const defaultConfigPath = path.join(__dirname, "config.json");
+const userConfigPath = path.join(app.getPath('userData'), "config.json");
 
 // Read config.json with error handling
 let config;
 try {
-  config = JSON.parse(fs.readFileSync(path.join(__dirname, "config.json")));
+  // First, try to read the user's config file
+  if (fs.existsSync(userConfigPath)) {
+    config = JSON.parse(fs.readFileSync(userConfigPath));
+  } else {
+    // If it doesn't exist, copy the default config file to the user's folder
+    console.log("Creating config file in user data path.");
+    fs.copyFileSync(defaultConfigPath, userConfigPath);
+    config = JSON.parse(fs.readFileSync(userConfigPath));
+  }
 } catch (error) {
-  console.error("Error reading config.json:", error);
-  process.exit(1); // Exit the app if config is not available
+  console.error("Error reading or creating config.json:", error);
+  process.exit(1);
 }
 const clientId = config.clientId;
+// Initialize variables from the saved configuration
+let blocked = config.adBlockEnabled !== undefined ? config.adBlockEnabled : false;
+let minimizeToTray = config.minimizeToTrayEnabled !== undefined ? config.minimizeToTrayEnabled : true;
 
+// Function to save the current configuration to config.json
+function saveConfig() {
+  const newConfig = {
+    ...config,
+    adBlockEnabled: blocked,
+    minimizeToTrayEnabled: minimizeToTray
+  };
+
+  fs.writeFile(
+    userConfigPath,
+    JSON.stringify(newConfig, null, 2),
+    (err) => {
+      if (err) {
+        console.error("Error saving configuration:", err);
+      } else {
+        console.log("Configuration saved successfully.");
+      }
+    }
+  );
+}
 
 // Discord Rich Presence setup
 rpc.register(clientId);
@@ -261,6 +294,7 @@ if (!gotLock) {
         blocker.disableBlockingInSession(mainWindow.webContents.session);
         console.log("Ad blocker disabled");
       }
+      saveConfig();
     }
 
 
@@ -330,8 +364,10 @@ if (!gotLock) {
             label: t("minimize_to_tray"),
             type: "checkbox",
             checked: minimizeToTray,
-            checked: true,
-            enabled: false,
+            click: (menuItem) => {
+              minimizeToTray = menuItem.checked;
+              saveConfig();
+            },
           },
           { type: "separator" },
           {


### PR DESCRIPTION
### Summary of Changes

This pull request contains two commits.

1.  **Multilanguage Support:** Adds a new i18n module, providing a structured way to handle different languages. The initial Spanish language file is included.

2.  **Persistent User Configuration:** Adds the ability to save user settings to a writable directory, ensuring that preferences like the adblocker state persist between sessions.